### PR TITLE
Strip "old " from times when rasp bitmaps being regenerated. 

### DIFF
--- a/app/src/main/java/com/fisincorporated/soaringforecast/soaring/forecast/ForecastMapper.java
+++ b/app/src/main/java/com/fisincorporated/soaringforecast/soaring/forecast/ForecastMapper.java
@@ -90,9 +90,17 @@ public class ForecastMapper implements OnMapReadyCallback, GoogleMap.OnMarkerCli
     // ---- Forecast overlay ------------------------------------
     // 100% opacity = 0% transnparent
     public void setGroundOverlay(Bitmap bitmap) {
+
         if (bitmap == null) {
-            return;
+            if (googleMap !=null && forecastOverlay  != null){
+                forecastOverlay.remove();
+                forecastOverlay = null;
+                return;
+            } else {
+                return;
+            }
         }
+
         if (forecastOverlay == null) {
             GroundOverlayOptions forecastOverlayOptions = new GroundOverlayOptions()
                     .image(BitmapDescriptorFactory.fromBitmap(bitmap))

--- a/app/src/main/java/com/fisincorporated/soaringforecast/soaring/forecast/SoaringForecastFragment.java
+++ b/app/src/main/java/com/fisincorporated/soaringforecast/soaring/forecast/SoaringForecastFragment.java
@@ -162,9 +162,15 @@ public class SoaringForecastFragment extends DaggerFragment {
 
         // Get Rasp bitmap for the date/time selected and pass to mapper
         soaringForecastViewModel.getSelectedSoaringForecastImageSet().observe(this, soaringForecastImageSet -> {
-            soaringForecastImageBinding.soaringForecastImageLocalTime.setText(soaringForecastImageSet.getLocalTime());
-            forecastMapper.setGroundOverlay(soaringForecastImageSet.getBodyImage().getBitmap());
-            soaringForecastImageBinding.soaringForecastScaleImage.setImageBitmap(soaringForecastImageSet.getSideImage().getBitmap());
+            if (soaringForecastImageSet != null) {
+                soaringForecastImageBinding.soaringForecastImageLocalTime.setText(soaringForecastImageSet.getLocalTime());
+                forecastMapper.setGroundOverlay(soaringForecastImageSet.getBodyImage().getBitmap());
+                soaringForecastImageBinding.soaringForecastScaleImage.setImageBitmap(soaringForecastImageSet.getSideImage().getBitmap());
+            } else {
+                soaringForecastImageBinding.soaringForecastImageLocalTime.setText("");
+                forecastMapper.setGroundOverlay(null);
+                soaringForecastImageBinding.soaringForecastScaleImage.setImageBitmap(null);
+            }
         });
 
         // Get Sounding bitmap for the date/time selected and pass to mapper

--- a/app/src/main/java/com/fisincorporated/soaringforecast/soaring/forecast/SoaringForecastImage.java
+++ b/app/src/main/java/com/fisincorporated/soaringforecast/soaring/forecast/SoaringForecastImage.java
@@ -6,7 +6,7 @@ public class SoaringForecastImage extends BitmapImage {
 
     private static final String separator = ":";
 
-    private String forecastTime = null;  //1300
+    private String forecastTime = null;  //1300 or might be old 1300 if RASP regenerating bitmaps
     private String forecastType = null;  // nam
     private String bitmapType = null;  // body footer header Constants.BODY, HEAD, FOOT, SIDE
     private String region = null;     // NewEngland

--- a/app/src/main/java/com/fisincorporated/soaringforecast/soaring/forecast/SoaringForecastViewModel.java
+++ b/app/src/main/java/com/fisincorporated/soaringforecast/soaring/forecast/SoaringForecastViewModel.java
@@ -388,6 +388,7 @@ public class SoaringForecastViewModel extends AndroidViewModel {
     private void loadRaspImages() {
         stopImageAnimation();
         soundingDisplay.setValue(false);
+        displayForecastImageSet(null);
         imageMap.clear();
         working.setValue(true);
         DisposableObserver disposableObserver = soaringForecastDownloader.getSoaringForecastForTypeAndDay(
@@ -481,6 +482,8 @@ public class SoaringForecastViewModel extends AndroidViewModel {
                     && imageSet.getBodyImage() != null) {
                 selectedSoaringForecastImageSet.setValue(imageSet);
             }
+        } else {
+            selectedSoaringForecastImageSet.setValue(null);
         }
     }
 


### PR DESCRIPTION
Also remove old map forecast overlay when new forecast selected but not yet available.