### PR TITLE
Save selected task between sessions and redisplay if defined. Updated…

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,6 +31,7 @@
 
         <activity
             android:name="com.fisincorporated.soaringforecast.settings.SettingsActivity"
+            android:parentActivityName=".drawer.WeatherDrawerActivity"
             android:screenOrientation="portrait">
         <meta-data
             android:name="android.support.PARENT_ACTIVITY"
@@ -39,6 +40,7 @@
 
        <activity
             android:name="com.fisincorporated.soaringforecast.task.TaskActivity"
+            android:parentActivityName=".drawer.WeatherDrawerActivity"
             android:screenOrientation="portrait">
            <meta-data
                android:name="android.support.PARENT_ACTIVITY"
@@ -47,6 +49,7 @@
 
         <activity
             android:name="com.fisincorporated.soaringforecast.satellite.SatelliteActivity"
+            android:parentActivityName=".drawer.WeatherDrawerActivity"
             android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
@@ -55,6 +58,7 @@
 
         <activity
             android:name="com.fisincorporated.soaringforecast.airport.AirportActivity"
+            android:parentActivityName=".drawer.WeatherDrawerActivity"
             android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
@@ -63,6 +67,7 @@
 
         <activity
             android:name="com.fisincorporated.soaringforecast.about.AboutActivity"
+            android:parentActivityName=".drawer.WeatherDrawerActivity"
             android:screenOrientation="portrait">
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"

--- a/app/src/main/java/com/fisincorporated/soaringforecast/app/AppPreferences.java
+++ b/app/src/main/java/com/fisincorporated/soaringforecast/app/AppPreferences.java
@@ -27,61 +27,36 @@ public class AppPreferences {
     //private static final String AIRPORT_LIST_KEY = "AIRPORT_LIST_KEY";
 
     private static final String SATELLITE_REGION_KEY = "SATELLITE_REGION";
-
     private static final String SATELLITE_IMAGE_TYPE_KEY = "SATELLITE_IMAGE_TYPE";
-
     private static final String DEFAULT_PREFS_SET = "DEFAULT_PREFS_SET";
-
     private static final String SOARING_FORECAST_MODEL_KEY = "SOARING_FORECAST_TYPE";
-
     private static final String SOARING_FORECAST_REGION_KEY = "SOARING_FORECAST_REGION";
-
     private static final String AIRPORT_CODES_FOR_METAR = "AIRPORT_CODES_FOR_METAR_TAF";
-
     private static final String FORECAST_OVERLAY_OPACITY = "FORECAST_OVERLAY_OPACITY";
-
     private static final String ICAO_CODE_DELIMITER = " ";
+    private static final String SELECTED_TASK_ID = "SELECTED_TASK_ID";
 
     // These string values are assigned in code so they match what is used in Settings
     private static String DISPLAY_SKYSIGHT_MENU_OPTION;
-
     private static String DISPLAY_DR_JACKS_MENU_OPTION;
-
     private static String RAW_METAR_KEY;
-
     private static String TEMPERATURE_UNITS_KEY;
-
     private static String WINDSPEED_UNITS_KEY;
-
     private static String ALTITUDE_UNITS_KEY;
-
     private static String DISTANCE_UNITS_KEY;
-
     private static String DECODE_TAF_METAR_KEY;
-
     private static String DISPLAY_FORECAST_SOUNDINGS;
 
-
     private SharedPreferences sharedPreferences;
-
     private boolean rawTafMetar;
-
     private boolean decodeTafMetar;
-
     private String imperialTemperatureUnits;
-
     private String imperialWindSpeedUnits;
-
     private String imperialAltitudeUnits;
-
     private String imperialDistanceUnits;
-
     private String satelliteRegionUS;
-
     private String satelliteImageTypeVis;
-
     private String soaringForecastType;
-
     private String soaringForecastDefaultRegion;
 
     @Inject
@@ -294,7 +269,6 @@ public class AppPreferences {
         SharedPreferences.Editor editor = sharedPreferences.edit();
         editor.putString(AIRPORT_CODES_FOR_METAR, icaoCodes);
         editor.apply();
-
     }
 
     /**
@@ -366,6 +340,16 @@ public class AppPreferences {
 
     public boolean getDisplayForecastSoundings(){
         return sharedPreferences.getBoolean(DISPLAY_FORECAST_SOUNDINGS, true);
+    }
+
+    public long getSelectedTaskId(){
+        return sharedPreferences.getLong(SELECTED_TASK_ID, -1);
+    }
+
+    public void setSelectedTaskId(long selectedTaskId){
+        SharedPreferences.Editor editor = sharedPreferences.edit();
+        editor.putLong(SELECTED_TASK_ID, selectedTaskId);
+        editor.apply();
     }
 
 }

--- a/app/src/main/java/com/fisincorporated/soaringforecast/soaring/forecast/SoaringForecastFragment.java
+++ b/app/src/main/java/com/fisincorporated/soaringforecast/soaring/forecast/SoaringForecastFragment.java
@@ -226,6 +226,7 @@ public class SoaringForecastFragment extends DaggerFragment {
                 return true;
             case R.id.forecast_menu_clear_task:
                 forecastMapper.removeTaskTurnpoints();
+                soaringForecastViewModel.setTaskId(-1);
                 showClearTaskMenuItem = false;
                 getActivity().invalidateOptionsMenu();
                 return true;

--- a/app/src/main/java/com/fisincorporated/soaringforecast/soaring/forecast/SoaringForecastViewModel.java
+++ b/app/src/main/java/com/fisincorporated/soaringforecast/soaring/forecast/SoaringForecastViewModel.java
@@ -75,7 +75,6 @@ public class SoaringForecastViewModel extends AndroidViewModel {
     private Constants.FORECAST_SOUNDING forecastSounding = Constants.FORECAST_SOUNDING.FORECAST;
 
     private boolean displaySoundings;
-    private boolean bypassLoadRasp = false; // used to prevent extraneous load of RASP forecasts
 
     public SoaringForecastViewModel(@NonNull Application application) {
         super(application);
@@ -187,7 +186,7 @@ public class SoaringForecastViewModel extends AndroidViewModel {
     /**
      * Get forecast dates for selected model (gfs currently has 7 dates, nam 3, rap 1
      *
-     * @return
+     * @return forecast dates for selected model
      */
     public MutableLiveData<List<ModelForecastDate>> getModelForecastDates() {
         modelForecastDates.setValue(createForecastDateListForSelectedModel());
@@ -632,6 +631,7 @@ public class SoaringForecastViewModel extends AndroidViewModel {
                 .subscribeOn(Schedulers.io())
                 .observeOn(AndroidSchedulers.mainThread())
                 .subscribe(taskTurnpointList -> {
+                            appPreferences.setSelectedTaskId(taskId);
                             taskTurnpoints.setValue(taskTurnpointList);
                         },
                         t -> {
@@ -642,6 +642,12 @@ public class SoaringForecastViewModel extends AndroidViewModel {
     }
 
     public MutableLiveData<List<TaskTurnpoint>> getTaskTurnpoints() {
+        if (taskTurnpoints.getValue() == null || taskTurnpoints.getValue().size() == 0) {
+            long taskId = appPreferences.getSelectedTaskId();
+            if (taskId != -1) {
+                getTask(taskId);
+            }
+        }
         return taskTurnpoints;
     }
 
@@ -675,4 +681,7 @@ public class SoaringForecastViewModel extends AndroidViewModel {
         super.onCleared();
     }
 
+    public void setTaskId(int taskId) {
+        appPreferences.setSelectedTaskId(taskId);
+    }
 }


### PR DESCRIPTION
Save selected task between sessions and redisplay if defined. Updated task/sounding marker logic so as not to have map recenter on marker when task/sounding clicked. Minor attempt to keep forecast page from starting from scratch when returning to app or hitting back button when further down in app.