### PR TITLE
Updated Windy to use leaflet1.4.0. 

### DIFF
--- a/app/src/main/assets/chrome_windy.html
+++ b/app/src/main/assets/chrome_windy.html
@@ -4,7 +4,7 @@
 <!-- point browser to this file via file:///(your path to)/assets/chrome_windy.html -->
 <html>
 <head>
-    <script src="https://unpkg.com/leaflet@0.7.7/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/leaflet@1.4.0/dist/leaflet.js"></script>
     <script src="https://api4.windy.com/assets/libBoot.js"></script>
     <style>
     #windy {

--- a/app/src/main/assets/windy.html
+++ b/app/src/main/assets/windy.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <script src="https://unpkg.com/leaflet@0.7.7/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/leaflet@1.4.0/dist/leaflet.js"></script>
     <script src="https://api4.windy.com/assets/libBoot.js"></script>
     <style>
     #windy {

--- a/app/src/main/assets/windy_test.html
+++ b/app/src/main/assets/windy_test.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <script src="https://unpkg.com/leaflet@0.7.7/dist/leaflet.js"></script>
+    <script src="https://unpkg.com/leaflet@1.4.0/dist/leaflet.js"></script>
     <script src="https://api4.windy.com/assets/libBoot.js"></script>
     <style>
     #windy {

--- a/app/src/main/java/org/soaringforecast/rasp/windy/WindyFragment.java
+++ b/app/src/main/java/org/soaringforecast/rasp/windy/WindyFragment.java
@@ -90,7 +90,7 @@ public class WindyFragment extends DaggerFragment {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             WebView.setWebContentsDebuggingEnabled(true);
         }
-        // prevent popups and new windows (but do not override the onCreateWindow() )
+        // prevents popups and new windows by not not overriding the onCreateWindow() )
         webView.getSettings().setSupportMultipleWindows(true);
 
         webView.setWebViewClient(new WebViewClient() {
@@ -101,14 +101,16 @@ public class WindyFragment extends DaggerFragment {
                     return false;
                 }
                 // Otherwise, start browser
-                Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+                // URL from clicking windy icon in form of https://www.windy.com/?utm_medium=efoertsch&utm_source=api4
+                // doesn't work (as of 5/12/2019) so use format below.
+                //Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+                Intent intent = new Intent(Intent.ACTION_VIEW
+                        , Uri.parse(getString(R.string.windy_com_parm,windyViewModel.getLat()
+                        , windyViewModel.getLong())));
                 startActivity(intent);
                 return true;
             }
 
-            public void onPageFinished(WebView view, String url) {
-                // ???
-            }
         });
 
         webView.measure(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -306,5 +306,6 @@
     <string name="forecast_menu_display_options">Display Options</string>
     <string name="sua">Special Use Airspace</string>
     <string name="clone">Clone</string>
+    <string name="windy_com_parm">http://www.windy.com/?%1$.4f,%2$.4f</string>
 
 </resources>


### PR DESCRIPTION
Updated webview to use leaflet1.4.0 per new Windy requirements. But when windy icon clicked supplied url did not work for either starting chrome browser or Windy app. So modified URL that  currently will only start browser, but still doesn't start Windy app.