### PR TITLE
Updated lat/long forecasts 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "org.soaringforecast.rasp"
         minSdkVersion 19
         targetSdkVersion 28
-        versionCode 10
-        versionName "1.5.2"
+        versionCode 11
+        versionName "1.5.3"
         //https://artemzin.com/blog/how-to-mock-dependencies-in-unit-integration-and-functional-tests-dagger-robolectric-instrumentation/
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         //testInstrumentationRunner "org.soaringforecast.rasp.app.OverrideApplicationTestRunner"

--- a/app/src/androidTest/java/org/soaringforecast/rasp/LatLngForecastTest.java
+++ b/app/src/androidTest/java/org/soaringforecast/rasp/LatLngForecastTest.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(AndroidJUnit4.class)
-public class PointForecastTest {
+public class LatLngForecastTest {
 
     Context context;
 

--- a/app/src/main/java/org/soaringforecast/rasp/soaring/forecast/ForecastMapper.java
+++ b/app/src/main/java/org/soaringforecast/rasp/soaring/forecast/ForecastMapper.java
@@ -46,7 +46,7 @@ import org.soaringforecast.rasp.common.messages.SnackbarMessage;
 import org.soaringforecast.rasp.repository.TaskTurnpoint;
 import org.soaringforecast.rasp.repository.Turnpoint;
 import org.soaringforecast.rasp.soaring.json.Sounding;
-import org.soaringforecast.rasp.soaring.messages.DisplayPointForecast;
+import org.soaringforecast.rasp.soaring.messages.DisplayLatLngForecast;
 import org.soaringforecast.rasp.soaring.messages.DisplaySounding;
 import org.soaringforecast.rasp.utils.BitmapImageUtils;
 import org.soaringforecast.rasp.utils.ViewUtilities;
@@ -538,16 +538,16 @@ public class ForecastMapper implements OnMapReadyCallback, GoogleMap.OnMarkerCli
 
     @Override
     public void onMapLongClick(LatLng latLng) {
-        EventBus.getDefault().post(new DisplayPointForecast(latLng));
+        EventBus.getDefault().post(new DisplayLatLngForecast(latLng));
     }
 
-    public void displayPointForecast(PointForecast pointForecast) {
+    public void displayLatLngForecast(LatLngForecast latLngForecast) {
         if (googleMap != null) {
             Marker marker = googleMap.addMarker(new MarkerOptions()
-                    .position(pointForecast.getLatLng())
+                    .position(latLngForecast.getLatLng())
                     .icon(BitmapDescriptorFactory.fromBitmap(
                             BitmapImageUtils.getBitmapFromVectorDrawable(context, R.drawable.transparent_marker)))); // transparent image
-            marker.setTag(pointForecast);
+            marker.setTag(latLngForecast);
             marker.showInfoWindow();
         }
 
@@ -561,7 +561,7 @@ public class ForecastMapper implements OnMapReadyCallback, GoogleMap.OnMarkerCli
 
     @Override
     public void onInfoWindowClose(Marker marker) {
-        if (marker.getTag() instanceof PointForecast) {
+        if (marker.getTag() instanceof LatLngForecast) {
             marker.remove();
         }
     }
@@ -615,9 +615,9 @@ public class ForecastMapper implements OnMapReadyCallback, GoogleMap.OnMarkerCli
                     view.setText(context.getString(R.string.unknow_error_in_render));
                 }
 
-            } else if (marker.getTag() instanceof PointForecast) {
-                PointForecast pointForecast = (PointForecast) marker.getTag();
-                view.setText(pointForecast.getForecastText());
+            } else if (marker.getTag() instanceof LatLngForecast) {
+                LatLngForecast latLngForecast = (LatLngForecast) marker.getTag();
+                view.setText(latLngForecast.getForecastText());
             }
 
         }

--- a/app/src/main/java/org/soaringforecast/rasp/soaring/forecast/LatLngForecast.java
+++ b/app/src/main/java/org/soaringforecast/rasp/soaring/forecast/LatLngForecast.java
@@ -2,11 +2,11 @@ package org.soaringforecast.rasp.soaring.forecast;
 
 import com.google.android.gms.maps.model.LatLng;
 
-public class PointForecast {
+public class LatLngForecast {
     private final LatLng latLng;
     private final String forecastText;
 
-    public PointForecast(LatLng latLng, String forecastText) {
+    public LatLngForecast(LatLng latLng, String forecastText) {
         this.latLng = latLng;
         this.forecastText = forecastText;
     }

--- a/app/src/main/java/org/soaringforecast/rasp/soaring/forecast/SoaringForecastDownloader.java
+++ b/app/src/main/java/org/soaringforecast/rasp/soaring/forecast/SoaringForecastDownloader.java
@@ -245,7 +245,7 @@ public class SoaringForecastDownloader implements CacheTimeListener {
     }
 
 
-    public Single<Response<ResponseBody>> getPointForecastAtLatLong(String region, String date, String model
+    public Single<Response<ResponseBody>> getLatLngForecast(String region, String date, String model
             , String time, String lat, String lon, String forecastType) {
        return client.getLatLongPointForecast(region, date, model, time, lat, lon, forecastType);
     }

--- a/app/src/main/java/org/soaringforecast/rasp/soaring/forecast/SoaringForecastFragment.java
+++ b/app/src/main/java/org/soaringforecast/rasp/soaring/forecast/SoaringForecastFragment.java
@@ -31,7 +31,7 @@ import org.soaringforecast.rasp.databinding.SoaringForecastBinding;
 import org.soaringforecast.rasp.repository.AppRepository;
 import org.soaringforecast.rasp.settings.SettingsActivity;
 import org.soaringforecast.rasp.soaring.json.Forecast;
-import org.soaringforecast.rasp.soaring.messages.DisplayPointForecast;
+import org.soaringforecast.rasp.soaring.messages.DisplayLatLngForecast;
 import org.soaringforecast.rasp.soaring.messages.DisplaySounding;
 import org.soaringforecast.rasp.task.TaskActivity;
 import org.soaringforecast.rasp.utils.StringUtils;
@@ -240,7 +240,7 @@ public class SoaringForecastFragment extends DaggerFragment {
 
         // Point forecast
         soaringForecastViewModel.getPointForecast().observe(this, pointForecast -> {
-            forecastMapper.displayPointForecast(pointForecast);
+            forecastMapper.displayLatLngForecast(pointForecast);
         });
 
         //ElapsedTimeUtil.showElapsedTime(TAG, "end of startObservers()");
@@ -419,8 +419,8 @@ public class SoaringForecastFragment extends DaggerFragment {
     }
 
     @Subscribe(threadMode = ThreadMode.MAIN)
-    public void onMessageEvent(DisplayPointForecast pointForecast) {
-        soaringForecastViewModel.displayPointForecast(pointForecast.getLatLng());
+    public void onMessageEvent(DisplayLatLngForecast latLngForecast) {
+        soaringForecastViewModel.displayLatLngForecast(latLngForecast.getLatLng());
     }
 
     // ---- Opacity for forecast overlay -----------------------

--- a/app/src/main/java/org/soaringforecast/rasp/soaring/messages/DisplayLatLngForecast.java
+++ b/app/src/main/java/org/soaringforecast/rasp/soaring/messages/DisplayLatLngForecast.java
@@ -2,11 +2,11 @@ package org.soaringforecast.rasp.soaring.messages;
 
 import com.google.android.gms.maps.model.LatLng;
 
-public class DisplayPointForecast {
+public class DisplayLatLngForecast {
 
     private LatLng latLng;
 
-    public DisplayPointForecast(LatLng latLng) {
+    public DisplayLatLngForecast(LatLng latLng) {
         this.latLng = latLng;
     }
 

--- a/app/src/main/java/org/soaringforecast/rasp/utils/StringUtils.java
+++ b/app/src/main/java/org/soaringforecast/rasp/utils/StringUtils.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 
 import timber.log.Timber;
 
@@ -60,6 +61,10 @@ public class StringUtils {
 
     }
 
+    public static LinkedHashMap<String, String> getLinkedHashMapFromStringRes(Context context, @StringRes int stringRes) {
+        return new Gson().fromJson(context.getString(stringRes), new TypeToken<LinkedHashMap<String, String>>(){}.getType());
+
+        }
 
 
 }

--- a/app/src/main/res/values/point_forecast_parms.xml
+++ b/app/src/main/res/values/point_forecast_parms.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="point_forecast_parm_conversion">{\"wstar_bsratio\":\"wstar bsratio\", \"zsfclclmask\":\"zsfclcldif zsfclcl\"
+    <string name="point_forecast_parm_conversion" translatable="false">{\"wstar_bsratio\":\"wstar bsratio\"
+        , \"zsfclclmask\":\"zsfclcldif zsfclcl\"
         , \"zblclmask\":\"zblcldif zblcl\"
         , \"sfcwind0\":\"sfcwind0spd sfcwind0dir\"
         , \"sfcwind\":\"sfcwindspd sfcwinddir\"
@@ -12,4 +13,8 @@
         , \"press700\":\"press700 press700wspd press700wdir\"
         , \"press500\":\"press500 press500wspd press500wdir\"
         , \"wind950\":\"wind950spd wind950dir\"}</string>
+
+    <string name="location_forecast_standard_parms" translatable="false">wstar bsratio zsfclcldif zsfclcl zblcldif zblcl  blwindspd blwinddir </string>
+    <string name="location_forecast_wave_parms" translatable="false">press1000 press1000wspd press1000wdir press950 press950wspd press950wdir press850 press850wspd press850wdir" +
+                        " press700 press700wspd press700wdir press500 press500wspd press500wdir</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -302,7 +302,8 @@
     <string name="satellite">Satellite</string>
     <string name="roadmap">Roadmap</string>
     <string name="hybrid">Hybrid</string>
-    <string name="no_point_forecast_available">No point forecast available for %1$s.</string>
+    <string name="no_location_forecast_available">No point forecast available for %1$s.</string>
+    <string name="error_getting_location_forecasts">Error getting location forecasts</string>
     <string name="forecast_menu_display_options">Display Options</string>
     <string name="sua">Special Use Airspace</string>
     <string name="clone">Clone</string>

--- a/app/src/test/java/org/soaringforecast/rasp/test/SoaringForecastTest.java
+++ b/app/src/test/java/org/soaringforecast/rasp/test/SoaringForecastTest.java
@@ -127,13 +127,28 @@ public class SoaringForecastTest {
     //    @POST("cgi/get_rasp_blipspot.cgi")
     public void shouldGetALatLongPointForecastSeparateHeaderParmsTest() throws IOException {
         Response<ResponseBody> response = client.getLatLongPointForecast(
-                "NewEngland","2019-03-22","gfs","1100","43.132009","-72.157325",
-                "wstar+bsratio").blockingGet();
-        assertEquals("OK",response.message());
+                "NewEngland", "2019-05-16", "rap", "1100", "43.132009", "-72.157325",
+                "wstar bsratio zsfclcldif zsfclcl zblcldif zblcl sfcwind0spd sfcwind0dir sfcwindspd sfcwinddir blwindspd blwinddir bltopwindspd bltopwinddir").blockingGet();
+        assertEquals("OK", response.message());
         System.out.println(response.body().string());
         assertNotNull(response);
 
+    }
+
+    @Test
+    //region=NewEngland&date=2019-03-20&model=gfs&time=1000&lat=43.132009&lon=-72.157325&param=wstar bsratio
+    //    @POST("cgi/get_rasp_blipspot.cgi")
+    public void shouldGetALatLongWaveForecastSeparateHeaderParmsTest() throws IOException {
+        Response<ResponseBody> response = client.getLatLongPointForecast(
+                "NewEngland", "2019-05-17", "rap", "1100", "43.132009", "-72.157325",
+                "press1000 press1000wspd press1000wdir press950 press950wspd press950wdir press850 press850wspd press850wdir" +
+                        " press700 press700wspd press700wdir press500 press500wspd press500wdir").blockingGet();
+        assertEquals("OK", response.message());
+        System.out.println(response.body().string());
+        assertNotNull(response);
 
     }
+
+
 
 }


### PR DESCRIPTION
Updated lat/long forecast to include multiple forecast types based on 2 broad categories based on current forecast displayed. If current forecast of type thermal, cloud or wind  it displays thermal/cloud/wind lat/lng forecast, if forecast is wave related it displays wave related forecasts at the various pressure levels.

Also renamed various classes/methods/fields.  Updated/added test methods.
Updated versioncode/version name (Oops - should have incorporated it on last release)