### PR TITLE
Add options in Settings for onclick Turnpoint display

### DIFF
--- a/app/src/main/java/org/soaringforecast/rasp/app/AppPreferences.java
+++ b/app/src/main/java/org/soaringforecast/rasp/app/AppPreferences.java
@@ -49,6 +49,7 @@ public class AppPreferences {
     private static final String ORDERED_FORECAST_OPTIONS = "ORDERED_FORECAST_OPTIONS";
     private static final String CLEAR_CACHE_TIME_MINUTES = "CLEAR_CACHE_TIME_MINUTES";
 
+
     // These string values are assigned in code so they match what is used in Settings
     private static String DISPLAY_WINDY_MENU_OPTION;
     private static String DISPLAY_SKYSIGHT_MENU_OPTION;
@@ -62,6 +63,9 @@ public class AppPreferences {
     private static String DISPLAY_SUA_KEY;
     private static String DISPLAY_FORECAST_SOUNDINGS_KEY;
     private static String DISPLAY_TURNPOINTS_KEY;
+    private static String DISPLAY_TURNPOINT_SATELLITE_VIEW;
+    private static String DISPLAY_TURNPOINT_INFOWINDOW_VIEW;
+
 
     private SharedPreferences sharedPreferences;
     private boolean rawTafMetar;
@@ -74,6 +78,7 @@ public class AppPreferences {
     private String satelliteImageTypeVis;
     private String soaringForecastModel;
     private String soaringForecastDefaultRegion;
+
 
     private List<CacheTimeListener> cacheTimeListeners = Collections.synchronizedList(new ArrayList());
 
@@ -101,6 +106,8 @@ public class AppPreferences {
         DISPLAY_DR_JACKS_MENU_OPTION = context.getString(R.string.pref_add_dr_jacks_to_menu_key);
 
         DISPLAY_FORECAST_SOUNDINGS_KEY = context.getString(R.string.pref_display_forecast_soundings_key);
+        DISPLAY_TURNPOINT_SATELLITE_VIEW = context.getString(R.string.pref_display_turnpoint_satellite_view_key);
+        DISPLAY_TURNPOINT_INFOWINDOW_VIEW = context.getString(R.string.pref_display_turnpoint_infowindow_view_key);
 
         // these should never be needed but use these default values
         rawTafMetar = res.getBoolean(R.bool.pref_raw_taf_metar_value);
@@ -504,6 +511,17 @@ public class AppPreferences {
             cacheTimeListeners.remove(cacheTimeListener);
         }
 
+    }
+
+
+    // setter handled bu SettingsPreferenceFragment, default value must match value in display_preferences.xml
+    public boolean getDisplayTurnpointSatelliteView() {
+        return sharedPreferences.getBoolean(DISPLAY_TURNPOINT_SATELLITE_VIEW, true);
+    }
+
+    // setter handled bu SettingsPreferenceFragment, default value must match value in display_preferences.xml
+    public boolean getDisplayTurnpointInfoWindowView() {
+        return sharedPreferences.getBoolean(DISPLAY_TURNPOINT_INFOWINDOW_VIEW, true);
     }
 
 }

--- a/app/src/main/java/org/soaringforecast/rasp/soaring/forecast/ForecastMapper.java
+++ b/app/src/main/java/org/soaringforecast/rasp/soaring/forecast/ForecastMapper.java
@@ -46,6 +46,7 @@ import com.google.maps.android.data.geojson.GeoJsonPolygonStyle;
 
 import org.greenrobot.eventbus.EventBus;
 import org.soaringforecast.rasp.R;
+import org.soaringforecast.rasp.app.AppPreferences;
 import org.soaringforecast.rasp.common.messages.SnackbarMessage;
 import org.soaringforecast.rasp.repository.TaskTurnpoint;
 import org.soaringforecast.rasp.repository.Turnpoint;
@@ -113,6 +114,7 @@ public class ForecastMapper implements OnMapReadyCallback, GoogleMap.OnMarkerCli
     // MapType must be one of GoogleMap.MAP_TYPE_xxxx
     private int mapType = GoogleMap.MAP_TYPE_TERRAIN;
     private LatLngBounds visibleLatLngBounds;
+    private AppPreferences appPreferences;
 
     @Inject
     public ForecastMapper() {
@@ -121,6 +123,11 @@ public class ForecastMapper implements OnMapReadyCallback, GoogleMap.OnMarkerCli
     public ForecastMapper setContext(Context context) {
         this.context = context;
         resources = context.getResources();
+        return this;
+    }
+
+    public ForecastMapper setAppPreferences(AppPreferences appPreferences){
+        this.appPreferences = appPreferences;
         return this;
     }
 
@@ -403,8 +410,12 @@ public class ForecastMapper implements OnMapReadyCallback, GoogleMap.OnMarkerCli
 
         if (marker.getTag() instanceof Turnpoint) {
             lastMarkerOpened = marker;
-            EventBus.getDefault().post(new DisplayTurnpoint((Turnpoint) marker.getTag()));
-            //marker.showInfoWindow();
+            if (appPreferences.getDisplayTurnpointSatelliteView()) {
+                EventBus.getDefault().post(new DisplayTurnpoint((Turnpoint) marker.getTag()));
+            }
+            if (appPreferences.getDisplayTurnpointInfoWindowView()) {
+                marker.showInfoWindow();
+            }
             return true;
         }
         if (marker.getTag() instanceof TaskTurnpoint) {
@@ -454,7 +465,8 @@ public class ForecastMapper implements OnMapReadyCallback, GoogleMap.OnMarkerCli
                             } else if (getContainerFeature(polygon) != null) {
                                 listener.onFeatureClick(getContainerFeature(polygon));
                             } else {
-                                // listener.onFeatureClick(getFeature(multiObjectHandler(polygon)));
+                                // listener.onFeatureClick(getFeature(multiObjectHandler(polygon))); // commented out as getFeature is private so would give syntax error
+                                                                                                     // Fortunately project doesn't require this functionality
                             }
                         }
                     });
@@ -472,7 +484,8 @@ public class ForecastMapper implements OnMapReadyCallback, GoogleMap.OnMarkerCli
                                 ForecastMapper.this.onMarkerClick(marker);
                                 return true;
                             } else {
-                                // listener.onFeatureClick(getFeature(multiObjectHandler(marker)));
+                                // listener.onFeatureClick(getFeature(multiObjectHandler(marker))); // commented out as getFeature is private so would give syntax error
+                                                                                    // Fortunately project doesn't require this functionality
                             }
                             return false;
                         }
@@ -486,7 +499,8 @@ public class ForecastMapper implements OnMapReadyCallback, GoogleMap.OnMarkerCli
                             } else if (getContainerFeature(polyline) != null) {
                                 listener.onFeatureClick(getContainerFeature(polyline));
                             } else {
-                                //listener.onFeatureClick(getFeature(multiObjectHandler(polyline)));
+                                //listener.onFeatureClick(getFeature(multiObjectHandler(polyline)));// commented out as getFeature is private so would give syntax error
+                                                                                                   // Fortunately project doesn't require this functionality
                             }
                         }
                     });

--- a/app/src/main/java/org/soaringforecast/rasp/soaring/forecast/SoaringForecastFragment.java
+++ b/app/src/main/java/org/soaringforecast/rasp/soaring/forecast/SoaringForecastFragment.java
@@ -115,6 +115,7 @@ public class SoaringForecastFragment extends DaggerFragment {
     private void setupViews() {
         // TODO how to get from binding - soaringForecastBinding.soaringForecastMap - need to get as supportMapFragment
         forecastMapper.setContext(getContext()).displayMap((SupportMapFragment) this.getChildFragmentManager().findFragmentById(R.id.soaring_forecast_map));
+        forecastMapper.setAppPreferences(appPreferences);
         // opacity not worth having it bound in viewModel and forwarding changes.
         forecastMapper.setForecastOverlayOpacity(appPreferences.getForecastOverlayOpacity());
         soaringForecastBinding.soaringForecastSeekbarOpacity.setProgress(soaringForecastViewModel.getForecastOverlyOpacity());

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,17 @@
     <string name="pref_display_turnpoints">Display Turnpoints</string>
 
 
+    <string name="pref_display_turnpoint_satellite_view_key" translatable="false">Display_turnpoint_satellite_view_key</string>
+    <string name="pref_display_turnpoint_satellite_view">Display Turnpoint Satellite View</string>
+    <string name="pref_display_turnpoint_satellite_summary_text">On click on turnpoint on map</string>
+
+    <string name="pref_display_turnpoint_infowindow_view_key" translatable="false">Display_turnpoint_infowindow_key</string>
+    <string name="pref_display_turnpoint_infowindow_view">Display Turnpoint InfoWindow</string>
+    <string name="pref_display_turnpoint_infowindow_summary_text">On click on turnpoint on map</string>
+
+
+
+
     <!-- Label for the temperature units preference [CHAR LIMIT=30] -->
     <string name="pref_units_temp">Temperature</string>
     <string name="pref_units_temp_centigrade_label">Centigrade</string>

--- a/app/src/main/res/xml/display_preferences.xml
+++ b/app/src/main/res/xml/display_preferences.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <PreferenceCategory
         android:key="rasp_forecast_options_preferences_key"
@@ -18,6 +20,19 @@
             android:defaultValue="false"
             android:key="@string/pref_display_turnpoints_key"
             android:title="@string/pref_display_turnpoints"/>
+
+        <android.support.v7.preference.SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:key="@string/pref_display_turnpoint_satellite_view_key"
+            android:title="@string/pref_display_turnpoint_satellite_view"
+            app:summary="On click on turnpoint on map"/>
+
+        <android.support.v7.preference.SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:key="@string/pref_display_turnpoint_infowindow_view_key"
+            android:title="@string/pref_display_turnpoint_infowindow_view"
+            app:summary="On click on turnpoint on map"/>
+
 
     </PreferenceCategory>
 


### PR DESCRIPTION
Add options in Settings to display turnpoint satellite view and/or infowindow when turnpoint clicked on forecast map.